### PR TITLE
Shutdown on init fail

### DIFF
--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -825,7 +825,7 @@ bool UbloxNode::configureUblox() {
     return false;
   }
   return true;
-  }
+}
 
 void UbloxNode::configureInf() {
   ublox_msgs::msg::CfgINF msg;

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -820,11 +820,12 @@ bool UbloxNode::configureUblox() {
       }
     }
   } catch (const std::exception& e) {
-    RCLCPP_FATAL(this->get_logger(), "Error configuring u-blox: %s", e.what());
+    RCLCPP_FATAL(this->get_logger(), "Error configuring u-blox: %s. shutting down ublox node...", e.what());
+    throw std::runtime_error("Error configuring u-blox");
     return false;
   }
   return true;
-}
+  }
 
 void UbloxNode::configureInf() {
   ublox_msgs::msg::CfgINF msg;


### PR DESCRIPTION
Throw a Runtime exception in configure function if initialization not successful. This should cause the node to crash and be automatically restarted.